### PR TITLE
[DRAFT] Add int8 KV-cache quantization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,33 @@ Bandwidth achieved: 1439.13 GB/s
 ```
 
 Note: Running on an A100 80GB, albeit power-limited to 330 watts. Empirically, seems like peak bandwidth is about 1700 GB/s.
+
+WIP: int8 KV-cache quantization
+
+With quantization and no compilation the performance is very low
+```
+time python generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 10 --fake false  --compile false --quantize true
+
+Time for inference 2: 78.11 sec total, 2.56 tokens/sec
+Bandwidth achieved: 34.51 GB/s
+```
+
+Compilation improves that by a lot. With quantization and compilation:
+```
+time python generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 10 --fake false  --compile true --quantize true
+
+Time for inference 10: 2.72 sec total, 73.43 tokens/sec
+Bandwidth achieved: 989.59 GB/s
+Memory used: 14.01 GB
+```
+
+For comparison, without quantization, but with compilation:
+```
+time python generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 10 --fake false  --compile true --quantize false
+
+Time for inference 10: 2.48 sec total, 80.78 tokens/sec
+Bandwidth achieved: 1088.72 GB/s
+Memory used: 13.84 GB
+```
+
+It is not yet clear why quantization increases, and not decreases, memory usage

--- a/convert_hf_checkpoint.py
+++ b/convert_hf_checkpoint.py
@@ -12,8 +12,8 @@ import torch
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from ..model import LLaMA, LLaMAConfig
-from ..utils import EmptyInitOnDevice, lazy_load, incremental_save
+from model import LLaMA, LLaMAConfig
+from utils import EmptyInitOnDevice, lazy_load, incremental_save
 
 
 @torch.no_grad()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,21 @@
+import torch
+
+from model import quantize_uint8, dequantize_uint8
+
+def run_test_quantization():
+
+    x = torch.rand(10, 8, dtype=torch.bfloat16)
+    x_q, coefs = quantize_uint8(x)
+
+    assert x_q.dtype == torch.uint8
+    assert x_q.shape == x.shape
+    x_deq = dequantize_uint8(x_q, coefs)
+
+    torch.testing.assert_close(x, x_deq, atol=0.05, rtol=0.01, msg=f"{x=}\n{x_deq=}\n{x_deq/x=}")
+
+
+def test_quantization(compile=True):
+    run_test_quantization()
+    if compile:
+        run_test_quantization_comp = torch.compile(run_test_quantization)
+        run_test_quantization_comp()

--- a/tests/test_repro.py
+++ b/tests/test_repro.py
@@ -1,0 +1,11 @@
+import torch
+
+# That won't work because PT2 doesn't support bitcast
+# which changes shape https://github.com/pytorch/pytorch/pull/102920
+def test_bitcast_view():
+    def run_bitcast_view(x: torch.Tensor):
+        return x.view(torch.uint8)
+    x = torch.tensor([1, 2, 3], dtype=torch.bfloat16)
+    y1 = run_bitcast_view(x)
+    y2 = torch.compile(run_bitcast_view)(x)
+    assert y1 == y2

--- a/utils.py
+++ b/utils.py
@@ -9,10 +9,10 @@ from contextlib import contextmanager
 
 import torch
 import torch.utils._device
-from lightning.fabric.strategies import DeepSpeedStrategy, FSDPStrategy
-from torch.distributed.fsdp import FullStateDictConfig
-from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
-from torch.distributed.fsdp import StateDictType
+# from lightning.fabric.strategies import DeepSpeedStrategy, FSDPStrategy
+# from torch.distributed.fsdp import FullStateDictConfig
+# from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+# from torch.distributed.fsdp import StateDictType
 from torch.serialization import normalize_storage_type
 
 llama_model_sizes = {
@@ -25,7 +25,7 @@ llama_model_sizes = {
 
 def llama_model_lookup(checkpoint: dict) -> str:
     """Returns the LLaMA model name from the checkpoint.
-    
+
     Checks the width of the lm_head.weight matrix, as these uniquely identify the model.
     """
     embedding_size = checkpoint['transformer.wte.weight'].shape[1]
@@ -38,33 +38,33 @@ def find_multiple(n: int, k: int) -> int:
     return n + k - (n % k)
 
 
-def save_model_checkpoint(fabric, model, file_path):
-    """Handles boilerplate logic for retrieving and saving the state_dict.
-    
-    This will be upstreamed to Fabric soon.
-    """
-    file_path = Path(file_path)
+# def save_model_checkpoint(fabric, model, file_path):
+#     """Handles boilerplate logic for retrieving and saving the state_dict.
 
-    if isinstance(fabric.strategy, DeepSpeedStrategy):
-        from deepspeed.utils.zero_to_fp32 import convert_zero_checkpoint_to_fp32_state_dict
+#     This will be upstreamed to Fabric soon.
+#     """
+#     file_path = Path(file_path)
 
-        fabric.save(file_path, {"model": model})
-        fabric.barrier()
-        if fabric.global_rank == 0:
-            # Create a consolidated checkpoint with the same name next to the deepspeed checkpoint
-            convert_zero_checkpoint_to_fp32_state_dict(file_path, file_path.with_suffix(".pth"))
-        return
+#     if isinstance(fabric.strategy, DeepSpeedStrategy):
+#         from deepspeed.utils.zero_to_fp32 import convert_zero_checkpoint_to_fp32_state_dict
 
-    if isinstance(fabric.strategy, FSDPStrategy):
-        save_policy = FullStateDictConfig(offload_to_cpu=(fabric.world_size > 1), rank0_only=True)
-        with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
-            state_dict = model._forward_module.state_dict()
-    else:
-        state_dict = model.state_dict()
+#         fabric.save(file_path, {"model": model})
+#         fabric.barrier()
+#         if fabric.global_rank == 0:
+#             # Create a consolidated checkpoint with the same name next to the deepspeed checkpoint
+#             convert_zero_checkpoint_to_fp32_state_dict(file_path, file_path.with_suffix(".pth"))
+#         return
 
-    if fabric.global_rank == 0:
-        torch.save(state_dict, file_path)
-    fabric.barrier()
+#     if isinstance(fabric.strategy, FSDPStrategy):
+#         save_policy = FullStateDictConfig(offload_to_cpu=(fabric.world_size > 1), rank0_only=True)
+#         with FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT, save_policy):
+#             state_dict = model._forward_module.state_dict()
+#     else:
+#         state_dict = model.state_dict()
+
+#     if fabric.global_rank == 0:
+#         torch.save(state_dict, file_path)
+#     fabric.barrier()
 
 
 class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):


### PR DESCRIPTION
This is WIP which adds row-wise uint8 KV-cache quantization in PT2-compilable way. Quantization parameters (scale and row minimum) are stored as separate tensors (buffers of `KVCache`)
TODO:
- Measure memory savings (for now didn't observe any)
- Think what's the best way to store the quantization parameters
- Add group-wise quantization