### PR TITLE
Fix OpenLLaMA weights downloading/converting

### DIFF
--- a/convert_hf_checkpoint.py
+++ b/convert_hf_checkpoint.py
@@ -12,8 +12,8 @@ import torch
 wd = Path(__file__).parent.parent.resolve()
 sys.path.append(str(wd))
 
-from ..model import LLaMA, LLaMAConfig
-from ..utils import EmptyInitOnDevice, lazy_load, incremental_save
+from model import LLaMA, LLaMAConfig
+from utils import EmptyInitOnDevice, lazy_load, incremental_save
 
 
 @torch.no_grad()

--- a/download_weights.md
+++ b/download_weights.md
@@ -14,7 +14,7 @@ git clone https://huggingface.co/openlm-research/open_llama_7b checkpoints/open-
 Or if you don't have `git-lfs` installed:
 
 ```bash
-python scripts/download.py --repo_id openlm-research/open_llama_7b --local_dir checkpoints/open-llama/7B
+python download.py --repo_id openlm-research/open_llama_7b --local_dir checkpoints/open-llama/7B
 ```
 
 Once downloaded, you should have a folder like this:
@@ -32,7 +32,7 @@ checkpoints/open-llama/
 Convert the weights to the Lit-LLaMA format:
 
 ```bash
-python scripts/convert_hf_checkpoint.py --checkpoint_dir checkpoints/open-llama/7B --model_size 7B
+python convert_hf_checkpoint.py --checkpoint_dir checkpoints/open-llama/7B --model_size 7B
 ```
 
 ### Original Meta weights
@@ -54,7 +54,7 @@ checkpoints/llama
 Convert the weights to the Lit-LLaMA format:
 
 ```bash
-python scripts/convert_checkpoint.py --model_size 7B
+python convert_checkpoint.py --model_size 7B
 ```
 
 > **Note**
@@ -91,7 +91,7 @@ git clone REPO_ID checkpoints/hf-llama/7B
 Or if you don't have `git-lfs` installed:
 
 ```bash
-python scripts/download.py --repo_id REPO_ID --local_dir checkpoints/hf-llama/7B
+python download.py --repo_id REPO_ID --local_dir checkpoints/hf-llama/7B
 ```
 
 Once downloaded, you should have a folder like this:
@@ -109,7 +109,7 @@ checkpoints/hf-llama/
 Convert the weights to the Lit-LLaMA format:
 
 ```bash
-python scripts/convert_hf_checkpoint.py --model_size 7B
+python convert_hf_checkpoint.py --model_size 7B
 ```
 
 > **Note**


### PR DESCRIPTION
`scripts/` folder was removed, but it is still referenced from the docs and code

Tested by successfully downloading and converting OpenLLaMA weights