### PR TITLE
Model parallelism for MLP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ To run benchmark.
 Model definition in `model.py`, generation code in `generate.py`.
 
 ```
-time python generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 10 --fake false  --compile true
+time torchrun --standalone --nproc_per_node=1 generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 10 --fake false  --compile true
 ```
 
 ```

--- a/generate.py
+++ b/generate.py
@@ -25,7 +25,7 @@ sys.path.append(str(wd))
 
 from model import LLaMA
 from tokenizer import Tokenizer
-from utils import lazy_load, llama_model_lookup, get_local_rank, get_local_world_size
+from utils import lazy_load, llama_model_lookup, LOCAL_RANK, LOCAL_WORLD_SIZE
 
 def fast_multinomial_sample_one(probs_sort):
     q = torch.empty_like(probs_sort).exponential_(1)
@@ -163,7 +163,7 @@ def main(
     assert tokenizer_path.is_file(), tokenizer_path
 
     precision = "bf16-true" if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else "32-true"
-    fabric = L.Fabric(devices=[get_local_rank()], precision=precision)
+    fabric = L.Fabric(devices=[LOCAL_RANK], precision=precision)
 
     print("Loading model ...", file=sys.stderr)
     t0 = time.time()
@@ -177,7 +177,7 @@ def main(
             model.load_state_dict(checkpoint)
 
         # Shard weights across local ranks
-        if get_local_world_size() > 1:
+        if LOCAL_WORLD_SIZE > 1:
             model.shard_state()
 
     print(f"Time to load model: {time.time() - t0:.02f} seconds.", file=sys.stderr)
@@ -210,30 +210,29 @@ def main(
         prof = contextlib.nullcontext() if i != num_samples - 1 or not profile else torch.profiler.profile()
         with prof:
             y = generate(model, encoded, max_new_tokens, temperature=temperature, top_k=top_k)
-        if get_local_rank() == 0 and hasattr(prof, "export_chrome_trace"):
+        if LOCAL_RANK == 0 and hasattr(prof, "export_chrome_trace"):
             prof.export_chrome_trace(f"{profile}.json")
         torch.cuda.synchronize()
         t = time.perf_counter() - t0
 
         model.reset_cache()
 
-        if get_local_rank() == 0:
+        if LOCAL_RANK == 0:
             print(tokenizer.decode(y))
             tokens_generated = y.size(0) - prompt_length
             tokens_sec = tokens_generated / t
             print(f"Time for inference {i + 1}: {t:.02f} sec total, {tokens_generated / t:.02f} tokens/sec", file=sys.stderr)
             print(f"Bandwidth achieved: {model_size * tokens_sec / 1e9:.02f} GB/s")
 
-    if get_local_rank() == 0:
+    if LOCAL_RANK == 0:
         print(f"Memory used: {torch.cuda.max_memory_reserved() / 1e9:.02f} GB", file=sys.stderr)
 
 
 if __name__ == "__main__":
     from jsonargparse import CLI
 
-    if get_local_world_size() > 1:
-        dist.init_process_group(backend="nccl", rank=get_local_rank(), world_size=get_local_world_size())
-        torch.cuda.set_device(get_local_rank())
+    dist.init_process_group(backend="nccl", rank=LOCAL_RANK, world_size=LOCAL_WORLD_SIZE)
+    torch.cuda.set_device(LOCAL_RANK)
 
     torch.set_float32_matmul_precision("high")
     warnings.filterwarnings(

--- a/model.py
+++ b/model.py
@@ -292,7 +292,8 @@ class MLP(nn.Module):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = F.silu(self.c_fc1(x)) * self.c_fc2(x)
         x = self.c_proj(x)
-        collectives.all_reduce(x, "sum", list(range(LOCAL_WORLD_SIZE)))
+        x = collectives.all_reduce(x, "sum", list(range(LOCAL_WORLD_SIZE)))
+
         return x
 
     def shard_state(self) -> None:

--- a/utils.py
+++ b/utils.py
@@ -23,6 +23,9 @@ llama_model_sizes = {
     8192: "65B",  # 65B n_embd=8192
 }
 
+# provided by torchrun
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK"))
+LOCAL_WORLD_SIZE = int(os.environ.get("LOCAL_WORLD_SIZE"))
 
 def llama_model_lookup(checkpoint: dict) -> str:
     """Returns the LLaMA model name from the checkpoint.
@@ -66,23 +69,6 @@ def save_model_checkpoint(fabric, model, file_path):
     if fabric.global_rank == 0:
         torch.save(state_dict, file_path)
     fabric.barrier()
-
-@functools.lru_cache(maxsize=1)
-def get_local_rank() -> int:
-    # provided by torchrun
-    if 'LOCAL_RANK' in os.environ:
-        return int(os.environ['LOCAL_RANK'])
-
-    return 0
-
-@functools.lru_cache(maxsize=1)
-def get_local_world_size() -> int:
-    # provided by torchrun
-    if 'LOCAL_WORLD_SIZE' in os.environ:
-        return int(os.environ['LOCAL_WORLD_SIZE'])
-
-    return 1
-
 
 class EmptyInitOnDevice(torch.overrides.TorchFunctionMode):
     def __init__(self, device=None, dtype=None, quantization_mode=None):


### PR DESCRIPTION
Described in [Megatron-LM](https://arxiv.org/pdf/1909.08053.pdf), we apply column-wise model parallelism to the LLaMa implementation in this repo. This PR sets up the distributed environment assuming generate.py is executed via `torchrun`, and applies parallelism only to MLP. We will apply it for the Self-attention module in a subsequent PR.

## Test
Using OpenLLaMa-7B and 8 A100s 40GB,

`torchrun --standalone --nproc_per_node=1 generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 5 --fake false  --compile true` should behave the same as previous `python generate.py [...]`

`torchrun --standalone --nproc_per_node=8 generate.py --prompt "Hello, my name is" --max_new_tokens 200 --num_samples 5 --fake false  --compile true`